### PR TITLE
refactor: change __hardware_gstreamer_test_picture to automatic stop

### DIFF
--- a/src/usr/lib/rsetup/tui/hardware/hardware.sh
+++ b/src/usr/lib/rsetup/tui/hardware/hardware.sh
@@ -10,7 +10,7 @@ __hardware_gstreamer_test_picture() {
     local temp
     temp="$(mktemp "${TEMPDIR:-/tmp}/tmp.XXXXXXXXXX.jpg")"
 
-    if gst-launch-1.0 v4l2src "device=/dev/$RSETUP_GSTREAMER_DEVICE" io-mode=4 ! \
+    if gst-launch-1.0 v4l2src "device=/dev/$RSETUP_GSTREAMER_DEVICE" io-mode=4 num-buffers=30 ! \
                       autovideoconvert ! \
                       video/x-raw,format=UYVY,width=1920,height=1080 ! \
                       jpegenc ! \


### PR DESCRIPTION
Set num-buffers=30 instead of 1 is because the first frame exposure parameters of some cameras are not ideal, you need to wait for the exposure algorithm to run.

* fixes https://github.com/radxa-pkg/rsetup/issues/79