### PR TITLE
edk2-menu: declare and assign separately

### DIFF
--- a/src/usr/lib/rsetup/cli/edk2-menu.sh
+++ b/src/usr/lib/rsetup/cli/edk2-menu.sh
@@ -23,7 +23,7 @@ load_edk2_setting() {
 }
 
 is_edk2_exist() {
-    command -v bootctl &>/dev/null && bootctl list &>/dev/null && load_edk2_setting
+    command -v bootctl &>/dev/null && bootctl list &>/dev/null && load_edk2_setting &>/dev/null
 }
 
 update_entry_overlays() {


### PR DESCRIPTION
To ensure that the function returns an error when there are obvious errors, avoiding misjudgment that the system supports edk2