### PR TITLE
fix: load_edk2_setting: use `cat` instead of `<`

### DIFF
--- a/src/usr/lib/rsetup/cli/edk2-menu.sh
+++ b/src/usr/lib/rsetup/cli/edk2-menu.sh
@@ -8,7 +8,7 @@ ALLOWED_RCONFIG_FUNC+=("load_edk2_setting")
 load_edk2_setting() {
     local version boot_kernel_dir
     version="${1:-$(uname -r)}"
-    if ! boot_kernel_dir="/boot/efi/$(< /etc/kernel/entry-token)/$version"; then
+    if ! boot_kernel_dir="/boot/efi/$(cat /etc/kernel/entry-token)/$version"; then
         return 1
     fi
 


### PR DESCRIPTION
And simplified the syntax.
Fixed the issue where running `<` on Debian 12 would cause the rsetup main process to exit.

Link: https://applink.feishu.cn/client/message/link/open?token=Ami%2F2XW%2Fg4ADaPmZ%2B5jhwBM%3D